### PR TITLE
Proposal to change PR#9 to trivago tgo

### DIFF
--- a/tio/bufferedreader.go
+++ b/tio/bufferedreader.go
@@ -305,13 +305,18 @@ func (buffer *BufferedReader) parseDelimiterRegex() ([]byte, int) {
 
 		nextIdx = delimiterIdx[1]
 
+		// If we look for end of message, we're done
 		if buffer.flags&BufferedReaderFlagRegexStart == 0 {
 			break
 		}
-		if startOffset > 0 {
+
+		// If we did find a start offset or if the first occurrence is not at
+		// the start of the message we are done
+		if startOffset > 0 || delimiterIdx[0] > 0 {
 			break
 		}
 
+		// Found start of first message, look for start of second message
 		startOffset = nextIdx
 	}
 

--- a/tio/bufferedreader.go
+++ b/tio/bufferedreader.go
@@ -301,21 +301,22 @@ func (buffer *BufferedReader) parseDelimiterRegex() ([]byte, int) {
 			return nil, 0 // ### return, incomplete ###
 		}
 
-		// If we look for end of message, we're done
+		// If we do end of message parsing, we're done
 		if buffer.flags&BufferedReaderFlagRegexStart != BufferedReaderFlagRegexStart {
 			nextIdx = delimiterIdx[1]
 			break
 		}
 
-		// We're done as this is the second pass (start offset != 0)
-		// If we have data before the match we're done with the remains of an incomplete message
+		// We're done if this is the second pass (start offset > 0)
+		// We're done if we have data before the match (incomplete message)
 		if startOffset > 0 || delimiterIdx[0] > 0 {
 			nextIdx = delimiterIdx[0] + startOffset
 			break
 		}
 
-		// Found start of first message, look for start of second message.
-		startOffset = delimiterIdx[1] + startOffset
+		// Found delimiter at start of data, look for the start of a second message.
+		// We don't need to add startOffset here as we never reach this if startOffset != 0
+		startOffset = delimiterIdx[1]
 	}
 
 	return buffer.extractMessage(nextIdx, 0)

--- a/tio/bufferedreader.go
+++ b/tio/bufferedreader.go
@@ -293,7 +293,6 @@ func (buffer *BufferedReader) parseMLE64() ([]byte, int) {
 // messages are separated by regexp
 func (buffer *BufferedReader) parseDelimiterRegex() ([]byte, int) {
 	startOffset := 0
-	nextIdx := 0
 
 	for {
 		delimiterIdx := buffer.delimiterRegexp.FindIndex(buffer.data[startOffset:buffer.end])
@@ -303,23 +302,19 @@ func (buffer *BufferedReader) parseDelimiterRegex() ([]byte, int) {
 
 		// If we do end of message parsing, we're done
 		if buffer.flags&BufferedReaderFlagRegexStart != BufferedReaderFlagRegexStart {
-			nextIdx = delimiterIdx[1]
-			break
+			return buffer.extractMessage(delimiterIdx[1], 0) // ### done, end of line ###
 		}
 
 		// We're done if this is the second pass (start offset > 0)
 		// We're done if we have data before the match (incomplete message)
 		if startOffset > 0 || delimiterIdx[0] > 0 {
-			nextIdx = delimiterIdx[0] + startOffset
-			break
+			return buffer.extractMessage(delimiterIdx[0]+startOffset, 0) // ### done, start of line ###
 		}
 
 		// Found delimiter at start of data, look for the start of a second message.
 		// We don't need to add startOffset here as we never reach this if startOffset != 0
 		startOffset = delimiterIdx[1]
 	}
-
-	return buffer.extractMessage(nextIdx, 0)
 }
 
 // ReadAll calls ReadOne as long as there are messages in the stream.

--- a/tio/bufferedreader.go
+++ b/tio/bufferedreader.go
@@ -303,7 +303,6 @@ func (buffer *BufferedReader) parseDelimiterRegex() ([]byte, int) {
 
 		// If we look for end of message, we're done
 		if buffer.flags&BufferedReaderFlagRegexStart != BufferedReaderFlagRegexStart {
-			println("done")
 			nextIdx = delimiterIdx[1]
 			break
 		}

--- a/tio/bufferedreader_test.go
+++ b/tio/bufferedreader_test.go
@@ -61,10 +61,10 @@ func TestBufferedReaderMultilineDelimiter(t *testing.T) {
 		tokens: []string{
 			"1111-12-06 1\n",
 			"2222-12-06T14:58:44.060 [qtp1860944798-11] a08b3652499144f4ac7bbf0bb12e012f ERROR portal2Service.App - \n" +
-			"java.sql.SQLTransientConnectionException: HikariPool-1 - Connection is not available, request timed out after 30013ms.\n" +
-			"  at com.zaxxer.hikari.pool.HikariPool.createTimeoutException(HikariPool.java:676)\n" +
-			"  at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:190)\n" +
-			"  ... 21 common frames omitted\n",
+				"java.sql.SQLTransientConnectionException: HikariPool-1 - Connection is not available, request timed out after 30013ms.\n" +
+				"  at com.zaxxer.hikari.pool.HikariPool.createTimeoutException(HikariPool.java:676)\n" +
+				"  at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:190)\n" +
+				"  ... 21 common frames omitted\n",
 			"3333-12-06 3\n",
 		},
 		parsed: 0,
@@ -72,11 +72,15 @@ func TestBufferedReaderMultilineDelimiter(t *testing.T) {
 
 	parseData := strings.Join(data.tokens, "")
 	parseReader := strings.NewReader(parseData)
-	reader := NewBufferedReader(1024, 32, 0, "^\\d{4}-\\d{2}-\\d{2}")
+	reader := NewBufferedReader(1024, BufferedReaderFlagRegexStart, 0, "(?m)^\\d{4}-\\d{2}-\\d{2}")
 
 	err := reader.ReadAll(parseReader, data.write)
 	// data.expect.Equal(io.EOF, err)
-	data.expect.Equal(3, data.parsed)
+
+	data.expect.Equal(2, data.parsed)
+
+	remains := reader.ResetGetIncomplete()
+	data.expect.Greater(len(remains), 0)
 
 	msg, _, err := reader.ReadOne(parseReader)
 	data.expect.Equal(io.EOF, err)


### PR DESCRIPTION
## Reasons for the change:

TL;DR: Make the new regex functionality match the behaviour of current parsing modes.

The way the regex function has been build makes it behave differently than the other parsing modes.
The main problem - as already stated in the PR - is the way that incomplete data is (not) handled. This is required as data streams might not return all data with a single read and might thus require multiple read passes to generate one complete message.
In addition to this It should be up to the caller when and how to deal with incomplete data after multiple reads, e.g. by utilising a timeout. Existing parsing modes already provide such a behaviour, at least when using the ReadOne function.

Another change is the way delimiters are detected. Delimiters before your PR used "end of line markers".  Your PR introduced "start of line markers" which might not always be the desired usecase. As of this there are now two modes for start and end of line search.

Another benefit of the changes in this PR is, that the parsing algorithm is now a lot simpler, leaving less room for bugs.

## Why this PR here and not in trivago/tgo

This is meant to be a suggestion for improvements of [PR 9 in trivago/tgo](https://github.com/trivago/tgo/pull/9).

## Changes:

- Rename multiline to regex.
- Split into two modes: find start, find end.
- Leave unmatched data in the buffer to match behaviour of previous parsing modes.
- Add a possibility to get incomplete data from the buffer.
- Add edge cases to unit tests